### PR TITLE
Grab bag of edits

### DIFF
--- a/_assets/stylesheets/_navigation.scss
+++ b/_assets/stylesheets/_navigation.scss
@@ -84,6 +84,10 @@
     }
   }
 
+  a abbr {
+    text-decoration: none;
+  }
+
   .nav--primary {
     @include breakpoint(sm) {
       margin-bottom: 0;

--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -1,6 +1,6 @@
 andre-vornbrock:
   name: Andre Vornbrock
-  whois: Discovered MCS vulnerabilities - background in high security NDE
+  whois: Discovered MCS vulnerabilities --- background in high security NDE.
   title: High Security Lockpicking
   abstract: >
       Practical applications for how to pick nearly any high security lock with a sidebar.
@@ -10,7 +10,7 @@ andre-vornbrock:
 
 peter-field:
   name: Peter Field
-  whois: Director of Research at Medeco Security Locks
+  whois: Director of Research at Medeco Security Locks.
   title: Elements of Lock Cylinder Design Cylinders & Keys made with Moveable Elements
   abstract: >
       ***Elements of Lock Cylinder Design*** is an overview of the parts or elements that make a lock cylinder, and the comparison of how variations in the individual elements can   increase or decrease the security of the lock.
@@ -28,7 +28,7 @@ peter-field:
 
 lucas-peter:
   name: Peter Field & Lucas Zhao
-  whois: Peter is Director of Research at Medeco Security Locks & Lucas is a Chinese and Asian lock researcher and aficionado
+  whois: Peter is Director of Research at Medeco Security Locks & Lucas is a Chinese and Asian lock researcher and aficionado.
   title: Interesting Chinese Cylinder Innovations
   abstract: >
       Many of the locks that have been manufactured and sold in China represent significant cylinder inventions that areoften overlooked.
@@ -57,7 +57,7 @@ connor-emily:
 jaakko-fagerlund:
   name: Jaakko Fagerlund
   twitter: JaakkoFagerlund
-  whois: Tool/die maker by profession, lockpick designer, safe cracker as a side job and very much into electronics and coding and combining all these to make whatever comes to mind
+  whois: Tool/die maker by profession, lockpick designer, safe cracker as a side job and very much into electronics and coding and combining all these to make whatever comes to mind.
   title: Manipulation aids in opening safe locks
   abstract: >
       An analysis of weaknesses present in typical mechanical safe combination locks and how to exploit them to gain knowledge of the combination by using electronic measuring tools and PC software.
@@ -79,7 +79,7 @@ jek-hyde:
   name: Jek Hyde
   twitter: HydeNS33k
   whois: >
-    Jek is an analyst specializing in physical infiltration and social engineering for the Walmart Red Team. She enjoys spreading the InfoSec gospel by sharing stories of how access controls can be bypassed by exploiting the weakest link in the security chain\: You. When Jek isn't burgling, she lifts heavy things, eats sweet potatoes, and jumps in mud puddles with her kids
+    Jek is an analyst specializing in physical infiltration and social engineering for the Walmart Red Team. She enjoys spreading the InfoSec gospel by sharing stories of how access controls can be bypassed by exploiting the weakest link in the security chain\: You. When Jek isn't burgling, she lifts heavy things, eats sweet potatoes, and jumps in mud puddles with her kids.
   title: Keynote
   abstract: >
       TBA
@@ -88,7 +88,7 @@ jek-hyde:
 attacus:
   name: Attacus
   twitter: attacus_au
-  whois: Attacus was born 1757 during a full moon.  She is currently an internet gremlin at Assurance and in her spare time enjoys licking poisonous wallpaper and patting dogs
+  whois: Attacus was born 1757 during a full moon.  She is currently an internet gremlin at Assurance and in her spare time enjoys licking poisonous wallpaper and patting dogs.
   title: How to Disappear Completely
   abstract: >
       If you've ever wanted an invisibility cloak, this talk is for you.
@@ -161,7 +161,7 @@ jos-weyers:
   name: Jos Weyers
   twitter: josweyers
   whois: >
-    Jos Weyers is a world-record holder in the field of lock impressioning and a mainstay participant at LockSport events around the world. A long-time member of TOOOL in the Netherlands and a key figure at the Hack42 hackerspace in Arnhem, Jos recently became the Vice-President of TOOOL.nl and now helps to oversee that organization and the LockCon conference. Jos is the mastermind behind the beehive42.org initiative. Some people know him as the Dutch Kilt guy. Featured in the New York Times. Voted #2 in the category "Hackers and Security" of the Nerd101-list of VrijNederland June 2015
+    Jos Weyers is a world-record holder in the field of lock impressioning and a mainstay participant at LockSport events around the world. A long-time member of TOOOL in the Netherlands and a key figure at the Hack42 hackerspace in Arnhem, Jos recently became the Vice-President of TOOOL.nl and now helps to oversee that organization and the LockCon conference. Jos is the mastermind behind the beehive42.org initiative. Some people know him as the Dutch Kilt guy. Featured in the New York Times. Voted #2 in the category "Hackers and Security" of the Nerd101-list of VrijNederland June 2015.
   title: >
     post-its, post-its, post-its everywhere (and how they relate to physical keys)
   abstract: >

--- a/_data/workshops.yml
+++ b/_data/workshops.yml
@@ -1,9 +1,9 @@
 jos-holly:
   name: Jos Weyers & Holly Poer
-  whois: Jos is the World Record Holder at impressioning and holds several international championship titles.  Holly is an American based locksmith and won 2nd in the 2016 USA Championships, making her the fastest American
+  whois: Jos is the World Record Holder at impressioning and holds several international championship titles. Holly is an American based locksmith and won 2nd in the 2016 USA Championships, making her the fastest American
   title: Impressioning with Jos Weyers and Holly Poer
   abstract: >
-      This is a very special workshop on impressioning, a covert entry technique used to generate a working key for a lock given only information obtained by manipulating a ***blank key*** in a lock. Unlike lockpicking, impressioning creates a fully working key for the lock which can be used to lock and unlock the cylinder at will. With practice, this technique can consistently create a key in 10-15 minutes ( and potentially faster! ). This will be a full, hands-on workshop on this technique.
+      This is a very special workshop on impressioning, a covert entry technique used to generate a working key for a lock given only information obtained by manipulating a ***blank key*** in a lock. Unlike lockpicking, impressioning creates a fully working key for the lock which can be used to lock and unlock the cylinder at will. With practice, this technique can consistently create a key in 10–15 minutes (and potentially faster!). This will be a full, hands-on workshop on this technique.
 
 
       <small>→ Twitter:</small> [**@josweyers**](https://twitter.com/josweyers)
@@ -21,8 +21,8 @@ jaakko-fagerlund:
 ben-grace-evengy-tom-david:
   name: Ben Low, Grace Nolan, Evengy Shatokhin, Tom Hennen & David Wearing
   twitter: __nolang
-  whois: Google is hosting this tamper evidence challenge to engage curiosity about the physicalintegrity aspects of local access attacks.
+  whois: Google is hosting this tamper evidence challenge to engage curiosity about the physical integrity aspects of local access attacks.
   title: Tamper Evidence Challenge
   abstract: >
-    Physical seals are intended to provide assurance that the sealed object has not been tamperedwith - to detect theft, contamination or unauthorised access. This challenge will be a hands-on, participant-led exercise in attempting to defeat a number of different tamper evident seals of dramatically different strengths and weaknesses, and also show some ways to detect tampering. Fame and glory will be awarded to participants who succeed in defeating each kind of seal.
+    Physical seals are intended to provide assurance that the sealed object has not been tampered with --- to detect theft, contamination or unauthorised access. This challenge will be a hands-on, participant-led exercise in attempting to defeat a number of different tamper evident seals of dramatically different strengths and weaknesses, and also show some ways to detect tampering. Fame and glory will be awarded to participants who succeed in defeating each kind of seal.
   hackergotchi: /images/hackergotchis/mystery.png

--- a/_layouts/speakers.liquid
+++ b/_layouts/speakers.liquid
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<h2 class="display-2--lighter">Our speakers</h2>
+<h2 class="display-2--lighter">{{ page.title }}</h2>
 
 {% assign speakers = site.data.speakers | sort %}
 

--- a/_layouts/training.liquid
+++ b/_layouts/training.liquid
@@ -2,11 +2,11 @@
 layout: default
 ---
 
-<h2 class="display-2--lighter">Training Information</h2>
+<h2 class="display-2--lighter">{{ page.title }}</h2>
 
-<p>
-  All traning will be conducted on 31st of May and the 1st of June.  All training can be purchased from our <a href="http://ozseccon.eventzilla.net/web/event?eventid=2138915646">EventZilla page</a>.
-</p>
+<p>All <a href="http://ozseccon.eventzilla.net/web/event?eventid=2138915646">training can be purchased from our EventZilla page</a>.
+
+<p>All traning will be conducted on May 31<sup>st</sup> and June 1<sup>st</sup>.</p>
 
 <h2 class="display-2--lighter">Our trainers</h2>
 

--- a/index.md
+++ b/index.md
@@ -10,12 +10,12 @@ title: "OzSecCon"
 
 New [speakers](/speakers/) and [workshops](/workshops/) have been added to the site! Please check them out. There's still a few more to come as the [CFP and CFW](/cfpw/) have not yet closed!
 
-Professional training has now been added for the first time. The first training course offered by OzSecCon is being run by Wayne Ronaldson. The training, 'Adverary Mindset - Red Team Training' will be run over two full days May 31st and June 1st. This is the first time this training has been offered in public and is being provided at a discounted price for those attending OzSecCon. The training will cover a large variety of physical and digital security topics and both practical and theoretical techniques will be demonstrated. See the [training page](/training/) for more details.
+Professional training has now been added for the first time. The first training course offered by OzSecCon is being run by Wayne Ronaldson. The training, 'Adverary Mindset --- Red Team Training' will be run over two full days, May 31<sup>st</sup> and June 1<sup>st</sup>. This is the first time this training has been offered in public and is being provided at a discounted price for those attending OzSecCon. The training will cover a large variety of physical and digital security topics and both practical and theoretical techniques will be demonstrated. See the [training page](/training/) for more details.
 
 ## Tickets
 
 OzSecCon tickets are now on sale!
-Please head to our [Eventzilla page](http://ozseccon.eventzilla.net/web/event?eventid=2138915646) to secure your ticket!
+Please head to our [Eventzilla page to secure your ticket!](http://ozseccon.eventzilla.net/web/event?eventid=2138915646)
 
 If you require any assistance to attend, please see the [FAQ](faq/#access-for-all).
 
@@ -27,7 +27,9 @@ OzSecCon is excited to announce our venue for 2018 will be the fantastic Melbour
 
 This, in conjunction with multiple classrooms and lecture theatres means we will be able to run multiple different activities simultaneously throughout the weekend.
 
-The locksmithing and metalworking departments are located in building B, in the north-west of the campus.  More information regarding this fantastic venue can be found [here](https://www.melbournepolytechnic.edu.au/campuses/heidelberg).
+The locksmithing and metalworking departments are located in building B, in the north-west of the campus.  
+
+For more on the campus venue, see the [the Melbourne Polytechnic Heidelberg campus page](https://www.melbournepolytechnic.edu.au/campuses/heidelberg).
 
 <iframe
   width="600"

--- a/trainers.md
+++ b/trainers.md
@@ -1,6 +1,0 @@
----
-layout: training
-permalink: /training/
-slug: training
-title: "Training"
----

--- a/training.md
+++ b/training.md
@@ -1,0 +1,6 @@
+---
+layout: training
+permalink: /training/
+slug: training
+title: "Training information"
+---


### PR DESCRIPTION
- Minor copy edits to (punctuation mostly)
  - homepage
  - speakers data
  - training page
- Simplifies the two training-related md files into one.
- Sets the page title for the speakers/training page to come from the MD file’s `page.title` instead.
- Removes the fugly user-agent set dotted underline from the CFP/CFW `<abbr>` in the nav.